### PR TITLE
Bugfix: When empty PasswordAttribute

### DIFF
--- a/src/Attributes/PasswordAttribute.php
+++ b/src/Attributes/PasswordAttribute.php
@@ -35,6 +35,8 @@ class PasswordAttribute extends Attribute implements iAttributeInterface
      */
     public function getSaveValue(Model $model)
     {
-        $model->{$this->name} = $this->value ?: null;
+        if ($this->value) {
+            $model->{$this->name} = $this->value;
+        }
     }
 }


### PR DESCRIPTION
Bugfix: When there's no password set, please don't update the value. In most cases this must be the case, but the PasswordAttribute is the exception here. Otherwise the 'password' field is going to be empy in de database.