### PR TITLE
Bug: Display nothing if there's no date inserted

### DIFF
--- a/src/Attributes/DateAttribute.php
+++ b/src/Attributes/DateAttribute.php
@@ -17,6 +17,10 @@ class DateAttribute extends Attribute implements iAttributeInterface
      */
     public function getDisplayValue(Model $model)
     {
+        if (! $model->{$this->name}) {
+            return '';
+        }
+        
         try {
             $date = new DateTime($model->{$this->name});
 

--- a/src/Attributes/DateTimeAttribute.php
+++ b/src/Attributes/DateTimeAttribute.php
@@ -16,6 +16,10 @@ class DateTimeAttribute extends DateAttribute implements iAttributeInterface
      */
     public function getDisplayValue(Model $model)
     {
+        if (! $model->{$this->name}) {
+            return '';
+        }
+        
         try {
             $date = new DateTime($model->{$this->name});
 


### PR DESCRIPTION
Don't display a default date when there's no actual date available