### PR TITLE
Hotfix: Iframe's not getting loaded when loading editor

### DIFF
--- a/public/js/attributes/medium/medium.js
+++ b/public/js/attributes/medium/medium.js
@@ -73,4 +73,11 @@ $(function () {
             }
         }
     }).data('MediumEditor', editor);
+    
+    setTimeout(function(){
+        $('.medium-insert-embed iframe').each(function(key, item){
+            var iframe = $(item);
+            iframe.attr('src', iframe.data('iframely-url'));
+        });
+    }, 1000);
 });


### PR DESCRIPTION
It loads the iframes into the editor when an api key has been set.